### PR TITLE
 Ported issue fix #2 - Handle empty intervals at the bounds

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,40 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "build",
+                "src",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "test",
+            "command": "dotnet",
+            "args": [
+                "run",
+                "-p",
+                "test/FsharpRampart.PropTests.fsproj"
+            ],
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            }
+        }
+    ]
+
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+
+# FsharpRampart Change Log
+All notable changes to this project will be documented in this file aiming to be true to the ported source.
+ 
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+ 
+## 2.0.0 - 2020-05-02
+ 
+Latest code ported. Behavior of relates has changed to accommodate the handling of empty intervals at the bounds. I consider this a breaking change, hence the major version bump. 
+ 
+### Changed
+- Add predicates for detecting empty intervals - Ported
+- Removed show function - unneeded with built-in fsharp print functions
+ 
+### Fixed
+- Handle empty intervals at the bounds - Ported issue fix [#2](https://github.com/tfausak/rampart/issues/2)
+ 
+## [1.0.2] - 2020-03-16
+  
+### Changed
+- Version bumped to more closely match ported repo
+
+### Fixed
+ - Ported issue fix [PR #5](https://github.com/tfausak/rampart/pull/5)
+ 
+## [0.1.0] - 2020-03-14
+ 
+### Added
+- Initial port of the haskell rampart lib to fsharp

--- a/README.md
+++ b/README.md
@@ -1,26 +1,47 @@
 # FsharpRampart
 .NET port (written in F#) of the [Haskell Rampart library](https://github.com/tfausak/rampart) by [Taylor Fausak](https://taylor.fausak.me/2020/03/13/relate-intervals-with-rampart/). 
 
+Available on  [Nuget](https://www.nuget.org/packages/FsharpRampart/)
+
 ![][interval relations]
 
 ## Examples
 
-```csharp
+```fsharp
 open FsharpRampart
 relate (toInterval (2, 4)) (toInterval (3, 5))
 // Output: Overlaps
 ```
 
-```csharp
+```fsharp
 let dt1 = (DateTime(2020,01,01), DateTime(2020,03,14)) |> toInterval
 let dt2 = (DateTime(2019,01,01), DateTime(2020,03,14)) |> toInterval
 relate dt1 dt2
 //Output: Finishes
 ```
 
-```csharp
+```fsharp
 invert Before
 //Output: After
+```
+
+```fsharp
+toInterval (2, 4) |> lesser
+// Output: 2
+
+toInterval (2, 4) |> greater
+// Output: 4
+```
+
+```fsharp
+toInterval (2, 2) |> isEmpty
+// Output: true
+
+toInterval (2, 3) |> isEmpty
+// Output: false
+
+toInterval (2, 3) |> isNonEmpty
+// Output: true
 ```
 
 ## C# interop
@@ -40,5 +61,8 @@ relate(dt1, dt2);
 invert(Relation.Before);
 //Output: After
 ```
+
+## Changelog
+[View changelog](/CHANGELOG.md)
 
 [interval relations]: ./interval-relations.svg

--- a/src/FsharpRampart.fsproj
+++ b/src/FsharpRampart.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>FsharpRampart</PackageId>
-    <Version>1.0.2</Version>
+    <Version>2.0.0</Version>
     <Authors>Dan Mannock</Authors>
     <Company>Dan Mannock</Company>
     <PackageTags>F#;FSharp;Functional Programming</PackageTags>

--- a/src/Library.fs
+++ b/src/Library.fs
@@ -27,6 +27,10 @@ module Interval =
 
     let greater (Interval(_, y)) = y
 
+    let isEmpty (Interval(x, y)) = x = y
+
+    let isNonEmpty (Interval(x, y)) = x <> y
+
     type private ComparisonResult = | LT | EQ | GT
     let private compare x y = 
         if x < y then LT
@@ -39,19 +43,21 @@ module Interval =
         let gxly = compare (greater x) (lesser y)
         let gxgy = compare (greater x) (greater y)
         match (lxly, lxgy, gxly, gxgy) with
-        | (EQ, _, _, EQ) -> Equal
-        | (_, _, LT, _) -> Before
-        | (_, _, EQ, _) -> Meets
-        | (_, EQ, _, _) -> MetBy
-        | (_, GT, _, _) -> After
-        | (LT, _, _, LT) -> Overlaps
-        | (LT, _, _, EQ) -> FinishedBy
-        | (LT, _, _, GT) -> Contains
-        | (EQ, _, _, LT) -> Starts
-        | (EQ, _, _, GT) -> StartedBy
-        | (GT, _, _, LT) -> During
-        | (GT, _, _, EQ) -> Finishes
-        | (GT, _, _, GT) -> OverlappedBy
+        | (EQ,  _,  _, EQ) -> Equal
+        | ( _,  _, LT,  _) -> Before
+        | (LT,  _, EQ, LT) -> Meets
+        | ( _,  _, EQ,  _) -> Overlaps
+        | (GT, EQ,  _, GT) -> MetBy
+        | ( _, EQ,  _,  _) -> OverlappedBy
+        | ( _, GT,  _,  _) -> After
+        | (LT,  _,  _, LT) -> Overlaps
+        | (LT,  _,  _, EQ) -> FinishedBy
+        | (LT,  _,  _, GT) -> Contains
+        | (EQ,  _,  _, LT) -> Starts
+        | (EQ,  _,  _, GT) -> StartedBy
+        | (GT,  _,  _, LT) -> During
+        | (GT,  _,  _, EQ) -> Finishes
+        | (GT,  _,  _, GT) -> OverlappedBy
 
     let invert = function
         | After -> Before

--- a/test/PropTests.fs
+++ b/test/PropTests.fs
@@ -17,6 +17,11 @@ let fromIntervalSameAsReadingLesserAndGreater (x: int) (y: int) =
 
 Check.Quick fromIntervalSameAsReadingLesserAndGreater
 
+let relationWithSameValuesIsEqual (x: int) =
+    toInterval(x, x) |> isEmpty
+
+Check.Quick relationWithSameValuesIsEqual
+
 let relationWithIntervalsOrderSwappedAndInverted<'T when 'T : comparison> (x: 'T, y: 'T) (a: 'T, b: 'T) =
     let interval1 = toInterval(x, y)
     let interval2 = toInterval(a, b)

--- a/test/repltests.fsx
+++ b/test/repltests.fsx
@@ -1,4 +1,4 @@
-#r "bin/Debug/netstandard2.0/FsharpRampart.dll"
+#r "../src/bin/Debug/netstandard2.0/FsharpRampart.dll"
 open System
 open FsharpRampart
 
@@ -15,17 +15,10 @@ let test() =
     relate (toInterval (2, 4)) (toInterval (3, 5))
     // Relation = Overlaps
 
-    (1, 2) 
-    |> toInterval
-    |> show
-
     let dt1 = (DateTime(2020,01,01), DateTime(2020,03,14)) |> toInterval
     let dt2 = (DateTime(2019,01,01), DateTime(2020,03,14)) |> toInterval
     relate dt1 dt2
     // Relation = Finishes
-    
-    Before
-    |> Relation.show
 
     invert Before
     // Relation = After


### PR DESCRIPTION
Latest code ported. Behaviour of relates has changed to accommodate the handling of empty intervals at the bounds. I consider this a breaking change, hence the major version bump. 
 
### Changed
- Add predicates for detecting empty intervals - Ported
- Removed show function - unneeded with built-in fsharp print functions
 
### Fixed
- Handle empty intervals at the bounds - Ported issue fix [#2](https://github.com/tfausak/rampart/issues/2)